### PR TITLE
Added message parser case for add operation

### DIFF
--- a/src/MessageParser.ts
+++ b/src/MessageParser.ts
@@ -4,6 +4,7 @@ import { StrictEventEmitter } from 'strict-event-emitter-types';
 import { EventEmitter } from 'events';
 import { ProtocolOperation } from './ProtocolOperation';
 import { BindResponse } from './messages/BindResponse';
+import { AddResponse } from './messages/AddResponse';
 import { CompareResponse } from './messages/CompareResponse';
 import { DeleteResponse } from './messages/DeleteResponse';
 import { ExtendedResponse } from './messages/ExtendedResponse';
@@ -94,6 +95,11 @@ export class MessageParser extends (EventEmitter as { new(): MessageParserEmitte
     switch (protocolOperation) {
       case ProtocolOperation.LDAP_RES_BIND:
         message = new BindResponse({
+          messageId,
+        });
+        break;
+      case ProtocolOperation.LDAP_RES_ADD:
+        message = new AddResponse({
           messageId,
         });
         break;


### PR DESCRIPTION
After trying out the code a bit more, I have found out, that the `client.add` operation did not work. 

Specifically, it returned an error:
`Error: Protocol Operation not supported: 0x69`

Looking at the previous commits, you released a **version 1.1.0** (with add & modify functionality), where you probably forgot to parse an `ProtocolOperation.LDAP_RES_ADD` in `MessageParser.ts` file.

After this change, the add operation was functional.

Similar case is for `client.modify` operation, but that should be addressed in a separate pull request (since I had different problems with it as well).