### PR TITLE
Added Entry interface

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -28,6 +28,7 @@ import {
   CompareResult,
   SearchResponse,
   SearchReference,
+  Entry,
   SearchEntry,
   DeleteResponse,
   ExtendedResponse,
@@ -90,7 +91,7 @@ export interface SearchOptions {
 
 export interface SearchResult {
   // tslint:disable-next-line: array-type
-  searchEntries: { dn: string, [index: string]: string | string[] }[];
+  searchEntries: Entry[];
   searchReferences: string[];
 }
 

--- a/src/messages/SearchEntry.ts
+++ b/src/messages/SearchEntry.ts
@@ -8,6 +8,11 @@ export interface SearchEntryOptions extends MessageResponseOptions {
   attributes?: Attribute[];
 }
 
+export interface Entry {
+  dn: string;
+  [index: string]: string | string[];
+}
+
 export class SearchEntry extends MessageResponse {
   public protocolOperation: ProtocolOperation;
   public name: string;
@@ -31,8 +36,8 @@ export class SearchEntry extends MessageResponse {
     }
   }
 
-  public toObject(): { dn: string, [index: string]: string | string[] } {
-    const result: { dn: string, [index: string]: string | string[] } = {
+  public toObject(): Entry {
+    const result: Entry = {
       dn: this.name,
     };
 


### PR DESCRIPTION
I'm using ldapts my application code.
I oftten write `{ dn: string, [index: string]: string | string[] }` as type in my code.
I think that many user writes this code too.

So, I added `Entry` interface of  `{ dn: string, [index: string]: string | string[] }` and wrote`export Entry`.
We are able to use this interface because of `export`.
Also, ldapts code became a little simple.
