### PR TITLE
Filter error

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -6,6 +6,7 @@ import Timer = NodeJS.Timer;
 import { Attribute } from './Attribute';
 import { Change } from './Change';
 import { MessageParser } from './MessageParser';
+import { FilterParser } from './FilterParser';
 import { MessageResponseStatus } from './MessageResponseStatus';
 import { StatusCodeParser } from './StatusCodeParser';
 import { MessageParserError } from './errors';
@@ -494,15 +495,17 @@ export class Client {
       controls.push(pagedResultsControl);
     }
 
+    const filter = FilterParser.parseString(options.filter);
+
     const searchRequest = new SearchRequest({
       messageId: -1, // NOTE: This will be set from _sendRequest()
       baseDN: typeof baseDN === 'string' ? baseDN : baseDN.toString(),
       scope: options.scope,
-      filter: options.filter,
       attributes: options.attributes,
       returnAttributeValues: options.returnAttributeValues,
       sizeLimit: options.sizeLimit,
       timeLimit: options.timeLimit,
+      filter,
       controls,
     });
 

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -495,7 +495,7 @@ export class Client {
       controls.push(pagedResultsControl);
     }
 
-    const filter = FilterParser.parseString(options.filter);
+    const filter = FilterParser.parseString(options.filter as string);
 
     const searchRequest = new SearchRequest({
       messageId: -1, // NOTE: This will be set from _sendRequest()

--- a/tests/FilterParser.tests.ts
+++ b/tests/FilterParser.tests.ts
@@ -50,6 +50,13 @@ describe('FilterParser', () => {
         FilterParser.parseString('((cn=foo))');
       }).should.throw(Error, 'Invalid attribute name: (cn=foo');
     });
+
+    it('should throw for just parenthesis', () => {
+      (() => {
+        FilterParser.parseString('()');
+      }).should.throw(Error, 'Invalid attribute name:');
+    });
+
     it('should allow xml in filter string', () => {
       const result = FilterParser.parseString('(&(CentralUIEnrollments=<mydoc>*)(objectClass=User))');
       result.should.deep.equal(new AndFilter({


### PR DESCRIPTION
There is an error when closing a socket after running a search with a filter of ```()```. The error is ```Connection closed before message response was received```. I found this to be the case due to  the FilterParser calling ```parseString``` after a message has been queued for a response and throwing before it can actually send the message so it is left stale awaiting a response. The fix I added was to parse the filter and throwing before creating the message.