### PR TITLE
Fixed unhandled promise rejection regarding 'Connection closed before…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ldapts",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "LDAP client",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -838,6 +838,8 @@ export class Client {
       throw new Error('Socket connection not established');
     }
 
+    const messageContentBuffer = message.write();
+
     let messageResolve: (messageResponse?: MessageResponse) => void = () => {
       // Ignore this as a NOOP
     };
@@ -879,7 +881,7 @@ export class Client {
     }
 
     // Send the message to the socket
-    this.socket.write(message.write(), () => {
+    this.socket.write(messageContentBuffer, () => {
       if (message instanceof AbandonRequest) {
         logDebug(`Abandoned message: ${message.messageId}`);
         delete this.messageDetailsByMessageId[message.messageId.toString()];


### PR DESCRIPTION
Regarding the issue : https://github.com/ldapts/ldapts/issues/88 , I found that calling (by mistake) the modify command without a password resulted in an unjustified "unhandled promise rejection" related to the fact that the message was added to the `messageDetailsByMessageId` object before actually being sure that that message was going to get sent. In this case, the `message.write()` call failed (so no message get sent) and resulted in the unhandled rejection.