### PR TITLE
Allow more SASL mechanisms like DIGEST-MD5 and SCRAM-SHA-1

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -340,7 +340,7 @@ export class Client {
 
     const result = await this._send<AddResponse>(req);
     if (result.status !== MessageResponseStatus.Success) {
-      throw StatusCodeParser.parse(result.status, result.errorMessage);
+      throw StatusCodeParser.parse(result);
     }
   }
 
@@ -376,7 +376,7 @@ export class Client {
       case CompareResult.compareFalse:
         return false;
       default:
-        throw StatusCodeParser.parse(response.status, response.errorMessage);
+        throw StatusCodeParser.parse(response);
     }
   }
 
@@ -402,7 +402,7 @@ export class Client {
 
     const result = await this._send<DeleteResponse>(req);
     if (result.status !== MessageResponseStatus.Success) {
-      throw StatusCodeParser.parse(result.status, result.errorMessage);
+      throw StatusCodeParser.parse(result);
     }
   }
 
@@ -430,7 +430,7 @@ export class Client {
 
     const result = await this._send<ExtendedResponse>(req);
     if (result.status !== MessageResponseStatus.Success) {
-      throw StatusCodeParser.parse(result.status, result.errorMessage);
+      throw StatusCodeParser.parse(result);
     }
 
     return {
@@ -467,7 +467,7 @@ export class Client {
 
     const result = await this._send<ModifyResponse>(req);
     if (result.status !== MessageResponseStatus.Success) {
-      throw StatusCodeParser.parse(result.status, result.errorMessage);
+      throw StatusCodeParser.parse(result);
     }
   }
 
@@ -504,7 +504,7 @@ export class Client {
 
     const result = await this._send<ModifyDNResponse>(req);
     if (result.status !== MessageResponseStatus.Success) {
-      throw StatusCodeParser.parse(result.status, result.errorMessage);
+      throw StatusCodeParser.parse(result);
     }
   }
 
@@ -632,7 +632,7 @@ export class Client {
 
     const result = await this._send<BindResponse>(req);
     if (result.status !== MessageResponseStatus.Success) {
-      throw StatusCodeParser.parse(result.status, result.errorMessage);
+      throw StatusCodeParser.parse(result);
     }
   }
 
@@ -642,7 +642,7 @@ export class Client {
     const result = await this._send<SearchResponse>(searchRequest);
 
     if (result.status !== MessageResponseStatus.Success && !(result.status === MessageResponseStatus.SizeLimitExceeded && searchRequest.sizeLimit)) {
-      throw StatusCodeParser.parse(result.status, result.errorMessage);
+      throw StatusCodeParser.parse(result);
     }
 
     for (const searchEntry of result.searchEntries) {

--- a/src/StatusCodeParser.ts
+++ b/src/StatusCodeParser.ts
@@ -39,87 +39,89 @@ import {
   TLSNotSupportedError,
   SaslBindInProgressError,
 } from './errors/resultCodeErrors';
+import type { BindResponse } from './messages';
+import type { MessageResponse } from './messages/MessageResponse';
 
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export class StatusCodeParser {
-  public static parse(code: number, message?: string): ResultCodeError {
-    switch (code) {
+  public static parse(result: MessageResponse): ResultCodeError {
+    switch (result.status) {
       case 1:
-        return new OperationsError(message);
+        return new OperationsError(result.errorMessage);
       case 2:
-        return new ProtocolError(message);
+        return new ProtocolError(result.errorMessage);
       case 3:
-        return new TimeLimitExceededError(message);
+        return new TimeLimitExceededError(result.errorMessage);
       case 4:
-        return new SizeLimitExceededError(message);
+        return new SizeLimitExceededError(result.errorMessage);
       case 7:
-        return new AuthMethodNotSupportedError(message);
+        return new AuthMethodNotSupportedError(result.errorMessage);
       case 8:
-        return new StrongAuthRequiredError(message);
+        return new StrongAuthRequiredError(result.errorMessage);
       case 11:
-        return new AdminLimitExceededError(message);
+        return new AdminLimitExceededError(result.errorMessage);
       case 12:
-        return new UnavailableCriticalExtensionError(message);
+        return new UnavailableCriticalExtensionError(result.errorMessage);
       case 13:
-        return new ConfidentialityRequiredError(message);
+        return new ConfidentialityRequiredError(result.errorMessage);
       case 14:
-        return new SaslBindInProgressError(message);
+        return new SaslBindInProgressError(result as BindResponse);
       case 16:
-        return new NoSuchAttributeError(message);
+        return new NoSuchAttributeError(result.errorMessage);
       case 17:
-        return new UndefinedTypeError(message);
+        return new UndefinedTypeError(result.errorMessage);
       case 18:
-        return new InappropriateMatchingError(message);
+        return new InappropriateMatchingError(result.errorMessage);
       case 19:
-        return new ConstraintViolationError(message);
+        return new ConstraintViolationError(result.errorMessage);
       case 20:
-        return new TypeOrValueExistsError(message);
+        return new TypeOrValueExistsError(result.errorMessage);
       case 21:
-        return new InvalidSyntaxError(message);
+        return new InvalidSyntaxError(result.errorMessage);
       case 32:
-        return new NoSuchObjectError(message);
+        return new NoSuchObjectError(result.errorMessage);
       case 33:
-        return new AliasProblemError(message);
+        return new AliasProblemError(result.errorMessage);
       case 34:
-        return new InvalidDNSyntaxError(message);
+        return new InvalidDNSyntaxError(result.errorMessage);
       case 35:
-        return new IsLeafError(message);
+        return new IsLeafError(result.errorMessage);
       case 36:
-        return new AliasDerefProblemError(message);
+        return new AliasDerefProblemError(result.errorMessage);
       case 48:
-        return new InappropriateAuthError(message);
+        return new InappropriateAuthError(result.errorMessage);
       case 49:
-        return new InvalidCredentialsError(message);
+        return new InvalidCredentialsError(result.errorMessage);
       case 50:
-        return new InsufficientAccessError(message);
+        return new InsufficientAccessError(result.errorMessage);
       case 51:
-        return new BusyError(message);
+        return new BusyError(result.errorMessage);
       case 52:
-        return new UnavailableError(message);
+        return new UnavailableError(result.errorMessage);
       case 53:
-        return new UnwillingToPerformError(message);
+        return new UnwillingToPerformError(result.errorMessage);
       case 54:
-        return new LoopDetectError(message);
+        return new LoopDetectError(result.errorMessage);
       case 64:
-        return new NamingViolationError(message);
+        return new NamingViolationError(result.errorMessage);
       case 65:
-        return new ObjectClassViolationError(message);
+        return new ObjectClassViolationError(result.errorMessage);
       case 66:
-        return new NotAllowedOnNonLeafError(message);
+        return new NotAllowedOnNonLeafError(result.errorMessage);
       case 67:
-        return new NotAllowedOnRDNError(message);
+        return new NotAllowedOnRDNError(result.errorMessage);
       case 68:
-        return new AlreadyExistsError(message);
+        return new AlreadyExistsError(result.errorMessage);
       case 69:
-        return new NoObjectClassModsError(message);
+        return new NoObjectClassModsError(result.errorMessage);
       case 70:
-        return new ResultsTooLargeError(message);
+        return new ResultsTooLargeError(result.errorMessage);
       case 71:
-        return new AffectsMultipleDSAsError(message);
+        return new AffectsMultipleDSAsError(result.errorMessage);
       case 112:
-        return new TLSNotSupportedError(message);
+        return new TLSNotSupportedError(result.errorMessage);
       default:
-        return new UnknownStatusCodeError(code, message);
+        return new UnknownStatusCodeError(result.status, result.errorMessage);
     }
   }
 }

--- a/src/errors/resultCodeErrors/SaslBindInProgressError.ts
+++ b/src/errors/resultCodeErrors/SaslBindInProgressError.ts
@@ -1,7 +1,12 @@
+import type { BindResponse } from '../../messages/BindResponse';
+
 import { ResultCodeError } from './ResultCodeError';
 
 export class SaslBindInProgressError extends ResultCodeError {
-  public constructor(message?: string) {
-    super(14, message || 'The server is ready for the next step in the SASL authentication process. The client must send the server the same SASL Mechanism to continue the process.');
+  public response: BindResponse;
+
+  public constructor(response: BindResponse) {
+    super(14, response.errorMessage || 'The server is ready for the next step in the SASL authentication process. The client must send the server the same SASL Mechanism to continue the process.');
+    this.response = response;
   }
 }

--- a/src/messages/BindRequest.ts
+++ b/src/messages/BindRequest.ts
@@ -6,12 +6,13 @@ import { ProtocolOperation } from '../ProtocolOperation';
 import type { MessageOptions } from './Message';
 import { Message } from './Message';
 
-export type SaslMechanism = 'EXTERNAL' | 'PLAIN';
+export const SASL_MECHANISMS = ['EXTERNAL', 'PLAIN', 'DIGEST-MD5', 'SCRAM-SHA-1'] as const;
+export type SaslMechanism = typeof SASL_MECHANISMS[number];
 
 export interface BindRequestMessageOptions extends MessageOptions {
   dn?: string;
   password?: string;
-  mechanism?: SaslMechanism;
+  mechanism?: string;
 }
 
 export class BindRequest extends Message {
@@ -21,7 +22,7 @@ export class BindRequest extends Message {
 
   public password: string;
 
-  public mechanism: SaslMechanism | undefined;
+  public mechanism: string | undefined;
 
   public constructor(options: BindRequestMessageOptions) {
     super(options);

--- a/src/messages/BindRequest.ts
+++ b/src/messages/BindRequest.ts
@@ -20,7 +20,7 @@ export class BindRequest extends Message {
 
   public dn: string;
 
-  public password: string;
+  public password?: string;
 
   public mechanism: string | undefined;
 
@@ -28,7 +28,7 @@ export class BindRequest extends Message {
     super(options);
     this.protocolOperation = ProtocolOperation.LDAP_REQ_BIND;
     this.dn = options.dn || '';
-    this.password = options.password || '';
+    this.password = options.password;
     this.mechanism = options.mechanism;
   }
 
@@ -39,9 +39,10 @@ export class BindRequest extends Message {
       // SASL authentication
       writer.startSequence(ProtocolOperation.LDAP_REQ_BIND_SASL);
       writer.writeString(this.mechanism);
-      writer.writeString(this.password);
+      if (typeof this.password === 'string') writer.writeString(this.password);
+
       writer.endSequence();
-    } else {
+    } else if (typeof this.password === 'string') {
       // Simple authentication
       writer.writeString(this.password, Ber.Context); // 128
     }

--- a/src/messages/BindResponse.ts
+++ b/src/messages/BindResponse.ts
@@ -1,3 +1,5 @@
+import type { BerReader } from 'asn1';
+
 import { ProtocolOperation } from '../ProtocolOperation';
 
 import type { MessageResponseOptions } from './MessageResponse';
@@ -6,8 +8,18 @@ import { MessageResponse } from './MessageResponse';
 export class BindResponse extends MessageResponse {
   public protocolOperation: ProtocolOperation;
 
+  public data: string[] = [];
+
   public constructor(options: MessageResponseOptions) {
     super(options);
     this.protocolOperation = ProtocolOperation.LDAP_RES_BIND;
+  }
+
+  public override parseMessage(reader: BerReader): void {
+    super.parseMessage(reader);
+    while (reader.remain > 0) {
+      const type = reader.peek();
+      this.data.push(reader.readString(typeof type === 'number' ? type : undefined));
+    }
   }
 }


### PR DESCRIPTION
With this pull request I have expanded the auto detection feature for SASL mechanisms and added a second function that allows SASL binds with any other mechanism that is not included in the list.

The bind response will also parse additional data, this allows reading the server's challenges for the challenge response type mechanisms.

Lastly I have noticed a warning about the packet being malformed on the initial request to the ldap server when using DIGEST-MD5. The password field should not be sent if it is not used.