### PR TITLE
Added OpenLDAP test server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  openldap:
+    build: tests/openldap
+    ports:
+      - '389:389'
+      - '636:636'
+    environment:
+      - LDAP_TLS_CERT_FILE=/certs/server.pem
+      - LDAP_TLS_KEY_FILE=/certs/server-key.pem
+      - LDAP_TLS_CA_FILE=/certs/client-ca.pem
+      - LDAP_TLS_VERIFY_CLIENTS=allow
+    volumes:
+      - ${LDAP_CERTS_DIR:-./dist/test-data/certs}:/certs:ro

--- a/tests/openldap/Dockerfile
+++ b/tests/openldap/Dockerfile
@@ -1,0 +1,13 @@
+FROM debian:bookworm
+RUN DEBIAN_FRONTEND=noninteractive \
+    apt-get update && \
+    apt-get install --yes --no-install-recommends \
+    ldap-utils \
+    slapd \
+    ssl-cert
+
+COPY files /
+
+EXPOSE 389 636
+
+CMD ["/docker-entrypoint.sh"]

--- a/tests/openldap/README.md
+++ b/tests/openldap/README.md
@@ -1,0 +1,25 @@
+# OpenLDAP Docker Container
+
+This directory contains a Dockerfile to build an OpenLDAP container for testing purposes.
+The container is based on Debian.
+
+## Usage
+
+To build and run the container use the following command in the top directory of the repository
+
+```bash
+docker-compose up -d
+```
+
+To stop the container
+
+```bash
+docker-compose down
+```
+
+The root user inside the container (`uid=0`, `gid=0`) is the administrator, and can authenticate without password by using the SASL EXTERNAL mechanism.
+
+```bash
+docker exec ldapts-openldap-1 ldapsearch -H ldapi:/// -Y EXTERNAL -b dc=example,dc=org   # list users
+docker exec ldapts-openldap-1 ldapsearch -H ldapi:/// -Y EXTERNAL -b cn=config           # list configuration
+```

--- a/tests/openldap/files/docker-entrypoint.sh
+++ b/tests/openldap/files/docker-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -ex
+
+rm -rf /data/* || true
+mkdir -p /data/config /data/db /data/ldif
+
+# process templates
+eval "cat <<< \"$(</templates/database.ldif)\"" > /data/ldif/database.ldif
+eval "cat <<< \"$(</templates/users-and-groups.ldif)\"" > /data/ldif/users-and-groups.ldif
+
+# import templates
+slapadd -v -n 0 -l /data/ldif/database.ldif -F /data/config
+slapadd -v -n 1 -l /data/ldif/users-and-groups.ldif -F /data/config
+
+/usr/sbin/slapd -d3 -s trace -h "ldap://0.0.0.0:389/ ldapi://%2Fvar%2Frun%2Fslapd%2Fldapi ldaps://0.0.0.0:636/" -F /data/config

--- a/tests/openldap/files/templates/database.ldif
+++ b/tests/openldap/files/templates/database.ldif
@@ -1,0 +1,86 @@
+#
+# LDAP configuration
+#
+
+dn: cn=config
+objectClass: olcGlobal
+cn: config
+olcPidFile: /var/run/slapd/slapd.pid
+olcArgsFile: /var/run/slapd/slapd.args
+olcTLSCertificateFile: ${LDAP_TLS_CERT_FILE:-/etc/ssl/certs/ssl-cert-snakeoil.pem}
+olcTLSCertificateKeyFile: ${LDAP_TLS_KEY_FILE:-/etc/ssl/private/ssl-cert-snakeoil.key}
+olcTLSCACertificateFile: ${LDAP_TLS_CA_FILE:-/etc/ssl/certs/ssl-cert-snakeoil.pem}
+olcTLSVerifyClient: ${LDAP_TLS_VERIFY_CLIENTS:-never}
+olcAuthzRegexp: cn=(.*) cn=\$1,ou=users,dc=example,dc=org
+
+
+#
+# Modules
+#
+
+dn: cn=module,cn=config
+objectClass: olcModuleList
+cn: module
+olcModulePath: /usr/lib/ldap
+olcModuleLoad: back_mdb
+olcModuleLoad: ppolicy
+
+
+#
+# Schemas
+#
+
+dn: cn=schema,cn=config
+objectClass: olcSchemaConfig
+cn: schema
+
+include: file:///etc/ldap/schema/core.ldif
+include: file:///etc/ldap/schema/cosine.ldif
+include: file:///etc/ldap/schema/inetorgperson.ldif
+include: file:///etc/ldap/schema/nis.ldif
+
+
+#
+# Frontend config
+#
+
+dn: olcDatabase=frontend,cn=config
+objectClass: olcDatabaseConfig
+objectClass: olcFrontendConfig
+olcDatabase: frontend
+
+
+#
+# Online configuration
+#
+
+dn: olcDatabase=config,cn=config
+objectClass: olcDatabaseConfig
+olcDatabase: config
+olcRootDN: gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth
+
+
+#
+# Backend database
+#
+
+dn: olcDatabase={1}mdb,cn=config
+objectClass: olcDatabaseConfig
+objectClass: olcMdbConfig
+olcDatabase: mdb
+olcSuffix: dc=example,dc=org
+olcDbDirectory: /data/db/
+olcRootDN: gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth
+# Note: all users in the group have manage permissions for testing purposes!
+olcAccess: to * by group.exact="cn=managers,ou=groups,dc=example,dc=org" manage by * break
+olcAccess: to attrs=userPassword,shadowLastChange
+  by self write
+  by anonymous auth
+  by * none
+olcAccess: to * by * none
+
+dn: olcOverlay=ppolicy,olcDatabase={1}mdb,cn=config
+objectClass: olcOverlayConfig
+objectClass: olcPPolicyConfig
+olcOverlay: ppolicy
+olcPPolicyDefault: cn=default,ou=ppolicy,dc=example,dc=org

--- a/tests/openldap/files/templates/users-and-groups.ldif
+++ b/tests/openldap/files/templates/users-and-groups.ldif
@@ -1,0 +1,100 @@
+#
+# Directory tree
+#
+
+dn: dc=example,dc=org
+objectClass: dcObject
+objectClass: organization
+dc: example
+o: example
+
+dn: ou=users,dc=example,dc=org
+objectClass: organizationalUnit
+ou: users
+
+dn: ou=groups,dc=example,dc=org
+objectClass: organizationalUnit
+ou: groups
+
+
+dn: ou=ppolicy,dc=example,dc=org
+objectClass: organizationalUnit
+ou: ppolicy
+
+#
+# Users
+#
+
+dn: cn=user,ou=users,dc=example,dc=org
+cn: user
+sn: user
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: shadowAccount
+userPassword:: $(echo -n "password" | base64)
+uid: user
+uidNumber: 1000
+gidNumber: 1000
+homeDirectory: /home/user
+
+# user that triggers changeAfterReset PasswordPolicyResponse error.
+dn: cn=mustchange,ou=users,dc=example,dc=org
+cn: mustchange
+sn: mustchange
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: shadowAccount
+objectClass: pwdPolicy
+userPassword:: $(echo -n "mustchange" | base64)
+uid: mustchange
+uidNumber: 1001
+gidNumber: 1001
+homeDirectory: /home/mustchange
+pwdReset: TRUE
+pwdAttribute: userPassword
+
+# user that triggers timeBeforeExpiration PasswordPolicyResponse warning after changing password once.
+dn: cn=expiring,ou=users,dc=example,dc=org
+cn: expiring
+sn: expiring
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: shadowAccount
+objectClass: pwdPolicy
+userPassword:: $(echo -n "expiring" | base64)
+uid: expiring
+uidNumber: 1002
+gidNumber: 1002
+homeDirectory: /home/expiring
+pwdAttribute: userPassword
+pwdPolicySubentry: cn=expiring,ou=ppolicy,dc=example,dc=org
+
+#
+# Groups
+#
+
+dn: cn=managers,ou=groups,dc=example,dc=org
+cn: managers
+objectClass: groupOfNames
+member: cn=user,ou=users,dc=example,dc=org
+
+#
+# Password policies
+#
+
+dn: cn=default,ou=ppolicy,dc=example,dc=org
+objectClass: pwdPolicy
+objectClass: organizationalRole
+cn: default
+pwdMustChange: TRUE
+pwdAttribute: userPassword
+
+dn: cn=expiring,ou=ppolicy,dc=example,dc=org
+objectClass: pwdPolicy
+objectClass: organizationalRole
+cn: expiring
+# How long after change (in seconds) before pssword is condsidered expired.
+pwdMaxAge: 31559999
+# How long before expiry (in seconds) to warn users.
+pwdExpireWarning: 31560000
+pwdAttribute: userPassword


### PR DESCRIPTION
This PR adds OpenLDAP container to help with local testing as requested in https://github.com/ldapts/ldapts/issues/106#issuecomment-1528116264

It does not use https://github.com/ldapjs/docker-test-openldap or https://hub.docker.com/r/bitnami/openldap/.
Motivation: the former is quite old, and latter does not give full flexibility to control all details. The suggested approach uses Debian package of `slapd` but adds own configuration, allowing full control on e.g. ppolicy overlay which can be used to test control messages with responses. Secondly: the Dockerfile and the scripts are based on something I have used in my own LDAP related tests in other projects, and I thought I can contribute this and it might be useful for ldapts as well.

Future work could include using it in the test suite.

