### PR TITLE
fix: modifyDN newSuperior not working with long form

### DIFF
--- a/src/messages/ModifyDNRequest.ts
+++ b/src/messages/ModifyDNRequest.ts
@@ -40,9 +40,8 @@ export class ModifyDNRequest extends Message {
     writer.writeBoolean(this.deleteOldRdn);
     if (this.newSuperior) {
       const length = Buffer.byteLength(this.newSuperior);
-
       writer.writeByte(0x80);
-      writer.writeByte(length);
+      writer.writeLength(length);
       writer._ensure(length);
       writer._buf.write(this.newSuperior, writer._offset);
       writer._offset += length;

--- a/tests/Client.tests.ts
+++ b/tests/Client.tests.ts
@@ -469,6 +469,32 @@ describe('Client', () => {
       args.newSuperior.should.equal(newSuperior);
       should.equal(args.controls, undefined);
     });
+
+    it('should handle newSuperior with the long form', async () => {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error
+      const stub = sinon.stub(client, '_send').returns(
+        new ModifyDNResponse({
+          messageId: 123,
+        }),
+      );
+
+      const dn = 'uid=groot,ou=Users,dc=foo,dc=com';
+      const newRdn = 'uid=groot';
+      const newSuperior =
+        'OU=O|10006677|重新命名选择权测试部门3,OU=O|10006677|重新命名选择权测试部门2,OU=O|10006677|重新命名选择权测试部门1,OU=O|10006677|重新命名选择权测试部门,OU=O|10002220|重新命名选择权,OU=重新命名选择权中心测试,ou=Users,dc=foo,dc=com';
+      const newDN = `${newRdn},${newSuperior}`;
+      await client.modifyDN(dn, newDN);
+
+      stub.restore();
+      stub.calledOnce.should.equal(true);
+      const args = stub.getCall(0).args[0] as ModifyDNRequest;
+      args.dn.should.equal(dn);
+      args.deleteOldRdn.should.equal(true);
+      args.newRdn.should.equal(newRdn);
+      args.newSuperior.should.equal(newSuperior);
+      should.equal(args.controls, undefined);
+    });
   });
 
   describe('#exop()', () => {


### PR DESCRIPTION
Hi, I use modifyDN to change DN. if newSuperior byte length less than 127 byte, it will use short form and sucess. But if newSuperior byte length greater than 127 byte, it will cause fail. Then you need to use long form to carry on. I use wireshark capture data, it show 「BER Error: length 1028619313 longer than tvb_reported_length_remaining: 130」.

Althought, modifyDN show response was sucessful. But it doesn't execute modify DN.

So, I compare two method to modifyDN between ldapts and ldapbrowser. I think it need 0x82 0x00 byte to use long form.

About Length octets [https://en.wikipedia.org/wiki/X.690#Length_octets](url)

I think same with the issue [https://github.com/ldapts/ldapts/issues/147](url)

![1732277912649](https://github.com/user-attachments/assets/aadbde0a-cefc-4794-b096-763aa3c1e10d)

