### PR TITLE
feat!: remove Node.js v18 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - 'main'
       - 'issue-**'
 
+  pull_request:
+    branches: ['main']
+
 permissions:
   contents: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['18', '20', '22']
+        node-version: ['20', '22']
 
     steps:
       - uses: actions/checkout@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@types/chai-as-promised": "8.0.2",
         "@types/debug": "4.1.12",
         "@types/mocha": "10.0.10",
-        "@types/node": ">=22",
+        "@types/node": ">=20",
         "@types/sinon": "17.0.4",
         "@types/whatwg-url": "13.0.0",
         "chai": "5.2.0",
@@ -50,7 +50,7 @@
         "unbuild": "3.5.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "url": "git+https://github.com/ldapts/ldapts.git"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "keywords": [
     "ldap",
@@ -86,7 +86,7 @@
     "@types/chai-as-promised": "8.0.2",
     "@types/debug": "4.1.12",
     "@types/mocha": "10.0.10",
-    "@types/node": ">=22",
+    "@types/node": ">=20",
     "@types/sinon": "17.0.4",
     "@types/whatwg-url": "13.0.0",
     "chai": "5.2.0",

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -72,7 +72,7 @@ interface MessageDetails {
   searchReferences?: SearchReference[];
   resolve: (message?: MessageResponse) => void;
   reject: (err: Error) => void;
-  timeoutTimer: NodeJS.Timer | null;
+  timeoutTimer: NodeJS.Timeout | null;
   socket: SocketWithId;
 }
 


### PR DESCRIPTION
BREAKING CHANGE: Drop support for Node.js v18. Minimum required version is now Node.js v20.

- Updated engines field in package.json
- Updated CI configuration to test on supported versions only