### PR TITLE
fix: avoid extra properties on Entry objects for case mis-match

### DIFF
--- a/src/messages/SearchEntry.ts
+++ b/src/messages/SearchEntry.ts
@@ -48,7 +48,9 @@ export class SearchEntry extends MessageResponse {
     };
 
     const hasExplicitBufferAttributes = explicitBufferAttributes.length;
+    const resultLCAttributes = new Set<string>();
     for (const attribute of this.attributes) {
+      resultLCAttributes.add(attribute.type.toLocaleLowerCase());
       let { values } = attribute;
       if (hasExplicitBufferAttributes && explicitBufferAttributes.includes(attribute.type)) {
         values = attribute.parsedBuffers;
@@ -67,7 +69,7 @@ export class SearchEntry extends MessageResponse {
 
     // Fill in any missing attributes that were requested
     for (const attribute of requestAttributes) {
-      if (typeof result[attribute] === 'undefined') {
+      if (typeof result[attribute] === 'undefined' && !resultLCAttributes.has(attribute.toLocaleLowerCase())) {
         result[attribute] = [];
       }
     }

--- a/tests/Client.tests.ts
+++ b/tests/Client.tests.ts
@@ -718,6 +718,22 @@ describe('Client', () => {
       ]);
     });
 
+    it('should return clean list of attributes even if the requested attribute is in the wrong case', async () => {
+      // NOTE: ldapsearch -H ldaps://localhost:636 -b dc=jumpcloud,dc=com -x -D uid=tony.stark,dc=jumpcloud,dc=com -w MyRedSuitKeepsMeWarm "(mail=peter.parker@marvel.com)"
+      const searchResult = await client.search(BASE_DN, {
+        scope: 'sub',
+        filter: `(mail=user1@${LDAP_DOMAIN})`,
+        attributes: ['homedirectory'],
+      });
+
+      searchResult.searchEntries.should.deep.equal([
+        {
+          dn: `uid=user1,${BASE_DN}`,
+          homeDirectory: '/home/user',
+        },
+      ]);
+    });
+
     it('should not return attribute values if returnAttributeValues=false', async () => {
       // NOTE: ldapsearch -H ldaps://localhost:636 -b dc=jumpcloud,dc=com -x -D uid=tony.stark,dc=jumpcloud,dc=com -w MyRedSuitKeepsMeWarm -A "(mail=peter.parker@marvel.com)"
       const searchResult = await client.search(BASE_DN, {


### PR DESCRIPTION
I added a test case that should demonstrate the issue, but basically if you ask for a list of attributes and one of them is cased differently than the server, you end up with two properties in your Entry output. For example:

```
client.search('blah', { 
   ...some filters,
   attributes: ['homedirectory']
})
```
would return
```
{
  homeDirectory: '/home/user',
  homedirectory: []
}
```
This PR corrects the output to:
```
{
  homeDirectory: '/home/user'
}
```
Alternatively, it would also be reasonable to output:
```
{
  homeDirectory: '/home/user',
  homedirectory: '/home/user'
}
```
or
```
{
  homedirectory: '/home/user'
}
```
but they kind of muddy the water, and that last one would destroy the information of what the server-preferred casing is, so I think they're probably both a bad idea.