### PR TITLE
feat: automatically detect binary data

### DIFF
--- a/src/Attribute.ts
+++ b/src/Attribute.ts
@@ -1,8 +1,11 @@
+import { TextDecoder } from 'node:util';
+
 import type { BerReader, BerWriter } from 'asn1';
 import asn1 from 'asn1';
 
 import { ProtocolOperation } from './ProtocolOperation.js';
 
+const utfDecoder = new TextDecoder('utf8', { fatal: true });
 const { Ber } = asn1;
 
 export interface AttributeOptions {
@@ -64,7 +67,13 @@ export class Attribute {
           if (isBinaryType) {
             (this.values as Buffer[]).push(buffer);
           } else {
-            (this.values as string[]).push(buffer.toString('utf8'));
+            try {
+              const decoded = utfDecoder.decode(buffer);
+              (this.values as string[]).push(decoded);
+            } catch {
+              // If the buffer cannot be decoded as UTF-8, treat it as binary data
+              (this.values as Buffer[]).push(buffer);
+            }
           }
         }
       }

--- a/src/messages/SearchEntry.ts
+++ b/src/messages/SearchEntry.ts
@@ -47,12 +47,11 @@ export class SearchEntry extends MessageResponse {
       dn: this.name,
     };
 
-    const hasExplicitBufferAttributes = explicitBufferAttributes.length;
     const resultLCAttributes = new Set<string>();
     for (const attribute of this.attributes) {
       resultLCAttributes.add(attribute.type.toLocaleLowerCase());
       let { values } = attribute;
-      if (hasExplicitBufferAttributes && explicitBufferAttributes.includes(attribute.type)) {
+      if (explicitBufferAttributes.includes(attribute.type) || values.some((value) => Buffer.isBuffer(value))) {
         values = attribute.parsedBuffers;
       }
 


### PR DESCRIPTION
It's a little bit cumbersome to explicitly call out attributes that contain non-UTF8 strings. We can pretty easily just keep things in buffer form if a strict UTF8 decoder throws an error.

I also added a check to keep uniformity within an attribute. So if there's a multivalue attribute and some items in the array are UTF8 strings but some are not, we return Buffers for ALL items in that property's array. We could also allow it to be mixed but it feels like this is a little cleaner.

This might be a breaking change worthy of a major version, but I think not, because if you were previously getting a string for a binary property, the string was corrupted and unusable anyway.

I also threw in some extra tests for `modify` since they seemed to be missing.