### PR TITLE
fix: treat empty tlsOptions as no TLS configuration

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -179,7 +179,9 @@ export class Client {
     }
 
     const isSecureProtocol = parsedUrl.scheme === 'ldaps';
-    this.secure = isSecureProtocol || !!this.clientOptions.tlsOptions;
+    // Check if tlsOptions has at least one defined property (not just an empty object or object with all undefined values)
+    const hasTlsOptions = !!this.clientOptions.tlsOptions && Object.values(this.clientOptions.tlsOptions).some((value) => value !== undefined);
+    this.secure = isSecureProtocol || hasTlsOptions;
     let host: string | null | undefined = null;
     if (typeof parsedUrl.host === 'string') {
       // Host might include a port, so split to get the hostname part

--- a/tests/Client.tests.ts
+++ b/tests/Client.tests.ts
@@ -66,6 +66,51 @@ describe('Client', () => {
         });
       }).should.not.throw(Error);
     });
+
+    it('should not enable secure mode with empty tlsOptions object', () => {
+      const client = new Client({
+        url: 'ldap://127.0.0.1',
+        tlsOptions: {},
+      });
+
+      // @ts-expect-error - private field
+      client.secure.should.equal(false);
+    });
+
+    it('should not enable secure mode with tlsOptions containing only undefined values', () => {
+      const client = new Client({
+        url: 'ldap://127.0.0.1',
+        tlsOptions: {
+          rejectUnauthorized: undefined,
+          ca: undefined,
+        },
+      });
+
+      // @ts-expect-error - private field
+      client.secure.should.equal(false);
+    });
+
+    it('should enable secure mode with tlsOptions containing defined values', () => {
+      const client = new Client({
+        url: 'ldap://127.0.0.1',
+        tlsOptions: {
+          rejectUnauthorized: false,
+        },
+      });
+
+      // @ts-expect-error - private field
+      client.secure.should.equal(true);
+    });
+
+    it('should enable secure mode with ldaps:// even with empty tlsOptions', () => {
+      const client = new Client({
+        url: 'ldaps://127.0.0.1',
+        tlsOptions: {},
+      });
+
+      // @ts-expect-error - private field
+      client.secure.should.equal(true);
+    });
   });
 
   describe('#isConnected', () => {


### PR DESCRIPTION
Empty tlsOptions objects or objects with only undefined properties were incorrectly enabling secure mode because JavaScript evaluates {} as truthy. Now checks that tlsOptions has at least one defined property before treating it as valid TLS configuration.

Fixes #262