### PR TITLE
chore: replace debug package with built-in util.debuglog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "8.1.1",
       "license": "MIT",
       "dependencies": {
-        "debug": "4.4.3",
         "strict-event-emitter-types": "2.0.0",
         "whatwg-url": "15.1.0"
       },
@@ -22,7 +21,6 @@
         "@semantic-release/release-notes-generator": "14.1.0",
         "@types/chai": "5.2.3",
         "@types/chai-as-promised": "8.0.2",
-        "@types/debug": "4.1.12",
         "@types/mocha": "10.0.10",
         "@types/node": ">=20",
         "@types/sinon": "21.0.0",
@@ -4936,6 +4934,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -10057,6 +10056,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
   },
   "homepage": "https://github.com/ldapts/ldapts#readme",
   "dependencies": {
-    "debug": "4.4.3",
     "strict-event-emitter-types": "2.0.0",
     "whatwg-url": "15.1.0"
   },
@@ -82,7 +81,6 @@
     "@semantic-release/release-notes-generator": "14.1.0",
     "@types/chai": "5.2.3",
     "@types/chai-as-promised": "8.0.2",
-    "@types/debug": "4.1.12",
     "@types/mocha": "10.0.10",
     "@types/node": ">=20",
     "@types/sinon": "21.0.0",

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -1,8 +1,8 @@
 import * as crypto from 'node:crypto';
 import * as net from 'node:net';
 import * as tls from 'node:tls';
+import { debuglog } from 'node:util';
 
-import debug from 'debug';
 import { parseURL } from 'whatwg-url';
 
 import { Attribute } from './Attribute.js';
@@ -39,7 +39,7 @@ import type { MessageResponse } from './messages/MessageResponse.js';
 import { StatusCodeParser } from './StatusCodeParser.js';
 
 const MAX_MESSAGE_ID = 2 ** 31 - 1;
-const logDebug = debug('ldapts');
+const logDebug = debuglog('ldapts');
 
 type SocketWithId = { id?: string } & (net.Socket | tls.TLSSocket);
 
@@ -214,7 +214,9 @@ export class Client {
         }
       }
 
-      logDebug(err.stack);
+      if (err.stack) {
+        logDebug(err.stack);
+      }
     });
 
     this.messageParser.on('message', this._handleSendResponse.bind(this));


### PR DESCRIPTION
Use Node.js built-in debuglog instead of external debug package.

Debug logging now uses NODE_DEBUG=ldapts instead of DEBUG=ldapts.