### PR TITLE
fix: make Filter.escape() work as intended and document it (#141)

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,23 @@ Substrings are wildcard filters. They use `*` as the wildcard. You can put more
 than one wildcard for a given string. For example you could do `(email=*@*bar.com)`
 to match any email of @bar.com or its subdomains like "<example@foo.bar.com>".
 
+This also means that any search filter syntax characters, such as the wildcard
+character `*` or parentheses, must be escaped (RFC2254 §4 _String Search Filter
+Definition_) in order to search for them and to prevent such characters in a
+string from an untrusted source to be misinterpreted as syntax characters
+(preventing injection attacks).
+
+That can be done using the `Filter.escape()` utility function:
+
+```ts
+import { Filter } from 'ldapts';
+const value = 'x*x@foo.net';
+const filter = `(email=${Filter.escape(value)})`;
+```
+
+That'll create a search filter to search for an exact match of `x*x@foo.net`,
+not treating `*` as a wildcard character.
+
 Now, let's say we also want to set our filter to include a
 specification that either the employeeType _not_ be a manager nor a secretary:
 

--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ that this will not use the LDAP TLS extended operation, but literally an SSL
 connection to port 636, as in LDAP v2). The full set of options to create a
 client is:
 
-| Attribute      | Description                                                                                |
-| -------------- | ------------------------------------------------------------------------------------------ |
-| url            | A valid LDAP URL (proto/host/port only)                                                    |
-| timeout        | Milliseconds client should let operations live for before timing out (Default: Infinity)   |
-| connectTimeout | Milliseconds client should wait before timing out on TCP connections (Default: OS default) |
-| tlsOptions     | TLS [connect() options](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback)  |
-| strictDN       | Force strict DN parsing for client methods (Default is true)                               |
+| Attribute        | Description                                                                                |
+| ---------------- | ------------------------------------------------------------------------------------------ |
+| `url`            | A valid LDAP URL (proto/host/port only)                                                    |
+| `timeout`        | Milliseconds client should let operations live for before timing out (Default: Infinity)   |
+| `connectTimeout` | Milliseconds client should wait before timing out on TCP connections (Default: OS default) |
+| `tlsOptions`     | TLS [connect() options](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback)  |
+| `strictDN`       | Force strict DN parsing for client methods (Default is true)                               |
 
 ### Specifying Controls
 
@@ -418,7 +418,7 @@ for an attribute `email` with a value of `foo@bar.com`. The syntax would be:
 const filter = `(email=foo@bar.com)`;
 ```
 
-ldapts requires all filters to be surrounded by '()' blocks. Ok, that was easy.
+ldapts requires all filters to be surrounded by '()' blocks. OK, that was easy.
 Let's now assume that you want to find all records where the email is actually
 just anything in the "@bar.com" domain and the location attribute is set to
 Seattle:
@@ -584,7 +584,7 @@ try {
 }
 ```
 
-## `using` declaration with Typescript
+## `using` declaration with TypeScript
 
 For more details look have a look at [using Declarations and Explicit Resource Management](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-2.html)
 

--- a/src/filters/ApproximateFilter.ts
+++ b/src/filters/ApproximateFilter.ts
@@ -38,6 +38,6 @@ export class ApproximateFilter extends Filter {
   }
 
   public override toString(): string {
-    return `(${this.escape(this.attribute)}~=${this.escape(this.value)})`;
+    return `(${Filter.escape(this.attribute)}~=${Filter.escape(this.value)})`;
   }
 }

--- a/src/filters/EqualityFilter.ts
+++ b/src/filters/EqualityFilter.ts
@@ -63,6 +63,6 @@ export class EqualityFilter extends Filter {
   }
 
   public override toString(): string {
-    return `(${this.escape(this.attribute)}=${this.escape(this.value)})`;
+    return `(${Filter.escape(this.attribute)}=${Filter.escape(this.value)})`;
   }
 }

--- a/src/filters/ExtensibleFilter.ts
+++ b/src/filters/ExtensibleFilter.ts
@@ -86,17 +86,17 @@ export class ExtensibleFilter extends Filter {
   }
 
   public override toString(): string {
-    let result = `(${this.escape(this.matchType)}:`;
+    let result = `(${Filter.escape(this.matchType)}:`;
 
     if (this.dnAttributes) {
       result += 'dn:';
     }
 
     if (this.rule) {
-      result += `${this.escape(this.rule)}:`;
+      result += `${Filter.escape(this.rule)}:`;
     }
 
-    result += `=${this.escape(this.value)})`;
+    result += `=${Filter.escape(this.value)})`;
 
     return result;
   }

--- a/src/filters/Filter.ts
+++ b/src/filters/Filter.ts
@@ -28,7 +28,7 @@ export abstract class Filter {
    * @param {string|Buffer} input
    * @returns Escaped string
    */
-  public escape(input: Buffer | string): string {
+  public static escape(input: Buffer | string): string {
     let escapedResult = '';
     if (Buffer.isBuffer(input)) {
       for (const inputChar of input) {

--- a/src/filters/Filter.ts
+++ b/src/filters/Filter.ts
@@ -66,6 +66,11 @@ export abstract class Filter {
     return escapedResult;
   }
 
+  /** @deprecated Use the static `Filter.escape()` instead. */
+  public escape(input: Buffer | string): string {
+    return Filter.escape(input);
+  }
+
   public abstract toString(): string;
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/filters/GreaterThanEqualsFilter.ts
+++ b/src/filters/GreaterThanEqualsFilter.ts
@@ -48,6 +48,6 @@ export class GreaterThanEqualsFilter extends Filter {
   }
 
   public override toString(): string {
-    return `(${this.escape(this.attribute)}>=${this.escape(this.value)})`;
+    return `(${Filter.escape(this.attribute)}>=${Filter.escape(this.value)})`;
   }
 }

--- a/src/filters/LessThanEqualsFilter.ts
+++ b/src/filters/LessThanEqualsFilter.ts
@@ -48,6 +48,6 @@ export class LessThanEqualsFilter extends Filter {
   }
 
   public override toString(): string {
-    return `(${this.escape(this.attribute)}<=${this.escape(this.value)})`;
+    return `(${Filter.escape(this.attribute)}<=${Filter.escape(this.value)})`;
   }
 }

--- a/src/filters/PresenceFilter.ts
+++ b/src/filters/PresenceFilter.ts
@@ -36,6 +36,6 @@ export class PresenceFilter extends Filter {
   }
 
   public override toString(): string {
-    return `(${this.escape(this.attribute)}=*)`;
+    return `(${Filter.escape(this.attribute)}=*)`;
   }
 }

--- a/src/filters/SubstringFilter.ts
+++ b/src/filters/SubstringFilter.ts
@@ -119,13 +119,13 @@ export class SubstringFilter extends Filter {
   }
 
   public override toString(): string {
-    let result = `(${this.escape(this.attribute)}=${this.escape(this.initial)}*`;
+    let result = `(${Filter.escape(this.attribute)}=${Filter.escape(this.initial)}*`;
 
     for (const anyItem of this.any) {
-      result += `${this.escape(anyItem)}*`;
+      result += `${Filter.escape(anyItem)}*`;
     }
 
-    result += `${this.escape(this.final)})`;
+    result += `${Filter.escape(this.final)})`;
 
     return result;
   }

--- a/tests/filters/Filter.test.ts
+++ b/tests/filters/Filter.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { Filter } from '../../src/index.js';
+
+describe('Filter', () => {
+  describe('#escape()', () => {
+    it('should not touch plain letters', () => {
+      expect(Filter.escape('x')).toBe('x');
+    });
+    it('should escape syntax characters', () => {
+      expect(Filter.escape('*').toLowerCase()).toBe('\\2a');
+      expect(Filter.escape('(').toLowerCase()).toBe('\\28');
+      expect(Filter.escape(')').toLowerCase()).toBe('\\29');
+      expect(Filter.escape('\\').toLowerCase()).toBe('\\5c');
+      expect(Filter.escape('\0').toLowerCase()).toBe('\\00');
+    });
+  });
+});

--- a/tests/filters/NotFilter.test.ts
+++ b/tests/filters/NotFilter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { EqualityFilter, NotFilter } from '../../src/index.js';
+import { EqualityFilter, Filter, NotFilter } from '../../src/index.js';
 
 describe('NotFilter', () => {
   describe('#toString()', () => {
@@ -14,7 +14,7 @@ describe('NotFilter', () => {
         filter: displayNameFoo,
       });
 
-      const fooName = `(${displayNameFoo.escape(displayNameFoo.attribute)}=${displayNameFoo.escape(displayNameFoo.value)})`;
+      const fooName = `(${Filter.escape(displayNameFoo.attribute)}=${Filter.escape(displayNameFoo.value)})`;
       expect(filter.toString()).toBe(`(!${fooName})`);
     });
   });

--- a/tests/filters/OrFilter.test.ts
+++ b/tests/filters/OrFilter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { EqualityFilter, OrFilter } from '../../src/index.js';
+import { EqualityFilter, Filter, OrFilter } from '../../src/index.js';
 
 describe('OrFilter', () => {
   describe('#toString()', () => {
@@ -18,8 +18,8 @@ describe('OrFilter', () => {
         filters: [displayNameFoo, displayNameBar],
       });
 
-      const fooName = `(${displayNameFoo.escape(displayNameFoo.attribute)}=${displayNameFoo.escape(displayNameFoo.value)})`;
-      const barName = `(${displayNameBar.escape(displayNameBar.attribute)}=${displayNameBar.escape(displayNameBar.value)})`;
+      const fooName = `(${Filter.escape(displayNameFoo.attribute)}=${Filter.escape(displayNameFoo.value)})`;
+      const barName = `(${Filter.escape(displayNameBar.attribute)}=${Filter.escape(displayNameBar.value)})`;
       expect(filter.toString()).toBe(`(|${fooName}${barName})`);
     });
   });


### PR DESCRIPTION
This makes the function static so that it can be called directly, without having to create any `Filter` object, requiring all existing code that expects it to be non-static to be updated. As this function until now hasn't been mentioned at all in the documentation, there shouldn't be too many (if any) users of this library that'll need to be updated.